### PR TITLE
Give error when GitHub Bearer Token is not created with correct scope

### DIFF
--- a/app/Service/GithubServiceProvider.php
+++ b/app/Service/GithubServiceProvider.php
@@ -75,6 +75,9 @@ JSON;
 
         if ($response['code'] == 200) {
             $data = json_decode($response['body'], true);
+            if($data['errors']) {
+                throw new \RuntimeException($data['errors'][0]['type'] . ' : ' . $data['errors'][0]['message']);
+            }
             $pagination_info = $data['data']['viewer']['sponsorshipsAsMaintainer']['pageInfo'];
             $sponsors = $data['data']['viewer']['sponsorshipsAsMaintainer']['nodes'];
 

--- a/app/Service/GithubServiceProvider.php
+++ b/app/Service/GithubServiceProvider.php
@@ -79,7 +79,7 @@ JSON;
 
         if ($response['code'] == 200) {
             $data = json_decode($response['body'], true);
-            if(true) {
+            if($data['errors']) {
                 $this->app->getPrinter()->error($data['errors'][0]['type'] . ' : ' . $data['errors'][0]['message']);
             }
             $pagination_info = $data['data']['viewer']['sponsorshipsAsMaintainer']['pageInfo'];

--- a/app/Service/GithubServiceProvider.php
+++ b/app/Service/GithubServiceProvider.php
@@ -15,12 +15,16 @@ class GithubServiceProvider implements ServiceInterface
     /** @var string Access Token */
     protected string $token;
 
+    /**@var App */
+    private App $app;
+
     static string $API_ENDPOINT = "https://api.github.com/graphql";
 
     public function load(App $app)
     {
         $this->agent = new Client();
         $this->token = $app->config->github_api_bearer;
+        $this->app = $app;
     }
 
     public function graphqlQuery($query, array $params = []): array
@@ -75,8 +79,8 @@ JSON;
 
         if ($response['code'] == 200) {
             $data = json_decode($response['body'], true);
-            if($data['errors']) {
-                throw new \RuntimeException($data['errors'][0]['type'] . ' : ' . $data['errors'][0]['message']);
+            if(true) {
+                $this->app->getPrinter()->error($data['errors'][0]['type'] . ' : ' . $data['errors'][0]['message']);
             }
             $pagination_info = $data['data']['viewer']['sponsorshipsAsMaintainer']['pageInfo'];
             $sponsors = $data['data']['viewer']['sponsorshipsAsMaintainer']['nodes'];


### PR DESCRIPTION
This is related to my problem in issue #4 , so I thought it would help to improve the error handling. 

I'm not sure if this is handle correctly. I don't know if your minicli have similar to Symfony console  `$output->writeln('<error>foo</error>');` So I throw a RuntimeException, but I'm up for suggestions :) 

Update: I found it (minicli output), so I added a suggestion to how it could be done, let me know what you think. 